### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,11 +14,11 @@ HT1621	KEYWORD1
 
 begin	KEYWORD2
 clear	KEYWORD2
-backlight KEYWORD2
-noBacklight KEYWORD2
-setBatteryLevel KEYWORD2
-print KEYWORD2
-display KEYWORD2
+backlight	KEYWORD2
+noBacklight	KEYWORD2
+setBatteryLevel	KEYWORD2
+print	KEYWORD2
+display	KEYWORD2
 noDisplay	KEYWORD2
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords