### PR TITLE
Make few functions virtual, changed private to protected

### DIFF
--- a/src/HT1621.h
+++ b/src/HT1621.h
@@ -56,14 +56,14 @@ public:
 	void clear();
 	void backlight();
 	void noBacklight();
-	void setBatteryLevel(int level);
+	virtual void setBatteryLevel(int level);
 	void print(long num, const char* flags="%6li", int precision = 0);
 	void print(double num, int precision = 3);
-	void printCelsius(double num); // precision is always 1
+	virtual void printCelsius(double num); // precision is always 1
 	void print(const char* str, bool leftPadded = false);
 	void display();
 	void noDisplay();
-private:
+protected:
 	int _cs_p;
 	int _wr_p;
 	int _data_p;
@@ -78,7 +78,7 @@ private:
 	void wrCMD(unsigned char CMD);
 	void setdecimalseparator(int dpposition);
 	void config(); // legacy: why not in begin func
-	void update();
-	char charToSegBits(char character);
+	virtual void update();
+	virtual char charToSegBits(char character);
 };
 #endif


### PR DESCRIPTION
In order to make some child class based on this one, for example for different LCDs I made some functions virtual and private changed to protected, so it can be used as parent class with rest of logic which controls HT1621 chip.

Example implementation is at https://github.com/petrkr/HT1621Small where I used it for small 4 digit LCD, which also use HT1621 controller.

Basically would be nice keep HT1621 as generic control class for that chip itself and then make child classes based on used LCD.

But this is minimal requirements to make it at least some way to be possible do own classes.